### PR TITLE
Add some account services related tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/onsi/ginkgo v1.15.0 // indirect
 	github.com/onsi/gomega v1.10.5 // indirect
 	github.com/openshift-online/ocm-sdk-go v0.1.157-0.20210204185703-869236f7f99c
+	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/tsenart/vegeta/v12 v12.8.4
 	github.com/zgalor/weberr v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1714,6 +1714,7 @@ github.com/samuel/go-zookeeper v0.0.0-20190810000440-0ceca61e4d75/go.mod h1:gi+0
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHiuO9LYd+cIxzgEHCQI4=
 github.com/satori/go.uuid v0.0.0-20160603004225-b111a074d5ef/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/uuid v0.0.0-20160927100844-b061729afc07/go.mod h1:B8HLsPLik/YNn6KKWVMDJ8nzCL8RP5WyfsnmvnAEwIU=
 github.com/satori/uuid v1.2.0/go.mod h1:B8HLsPLik/YNn6KKWVMDJ8nzCL8RP5WyfsnmvnAEwIU=

--- a/main.go
+++ b/main.go
@@ -141,4 +141,10 @@ func main() {
 		fmt.Printf("Error running list-subscriptions test: %v", err)
 		os.Exit(1)
 	}
+
+	err = tests.TestRegisterNewCluster(attacker, args.outputDirectory, duration, testID)
+	if err != nil {
+		fmt.Printf("Error running test-access-review: %v", err)
+		os.Exit(1)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/nimrodshn/cs-load-test/pkg/helpers"
 	"github.com/nimrodshn/cs-load-test/pkg/tests"
 	sdk "github.com/openshift-online/ocm-sdk-go"
-	uuid "github.com/satori/go.uuid"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
@@ -91,11 +90,12 @@ func init() {
 func main() {
 	flag.Parse()
 
+	// Consider passing a yaml map from test-name to rate as config file to allow more flexability.
+
 	connection, err := sdk.NewConnectionBuilder().
-		//Insecure(true).
-		//URL(args.gatewayURL).
-		//Client(args.clientID, args.clientSecret).
-		URL("https://api.integration.openshift.com").
+		Insecure(true).
+		URL(args.gatewayURL).
+		Client(args.clientID, args.clientSecret).
 		Tokens(args.token).
 		TransportWrapper(func(wrapped http.RoundTripper) http.RoundTripper {
 			return &helpers.CleanClustersTransport{Wrapped: wrapped}
@@ -107,44 +107,15 @@ func main() {
 	}
 	defer helpers.Cleanup(connection)
 	attacker := new(vegeta.Attacker)
-	//metrics := make(map[string]*vegeta.Metrics)
+	metrics := make(map[string]*vegeta.Metrics)
 
 	rate = vegeta.Rate{Freq: args.rate, Per: time.Second}
 	duration = time.Duration(args.durationInMin) * time.Minute
 	connAttacker = vegeta.Client(&http.Client{Transport: connection})
 	attacker = vegeta.NewAttacker(connAttacker)
 
-	//if err := tests.Run(attacker, metrics, rate, args.outputDirectory, duration); err != nil {
-	//	fmt.Printf("Error running create cluster load test: %v", err)
-	//	os.Exit(1)
-	//}
-
-	// testId is an identifier used to associate all tests in this test suite with each
-	// other
-	testID := uuid.NewV4().String()
-
-	// TODO: Throw all tests into an array and call them using a loop
-	err = tests.TestSelfAccessToken(attacker, args.outputDirectory, duration, testID)
-	if err != nil {
-		fmt.Printf("Error running self-access-token test: %v", err)
-		os.Exit(1)
-	}
-
-	err = tests.TestListSubscriptions(attacker, args.outputDirectory, duration, testID)
-	if err != nil {
-		fmt.Printf("Error running list-subscriptions test: %v", err)
-		os.Exit(1)
-	}
-
-	err = tests.TestAccessReview(attacker, args.outputDirectory, duration, testID)
-	if err != nil {
-		fmt.Printf("Error running list-subscriptions test: %v", err)
-		os.Exit(1)
-	}
-
-	err = tests.TestRegisterNewCluster(attacker, args.outputDirectory, duration, testID)
-	if err != nil {
-		fmt.Printf("Error running test-access-review: %v", err)
+	if err := tests.Run(attacker, metrics, rate, args.outputDirectory, duration); err != nil {
+		fmt.Printf("Error running create cluster load test: %v", err)
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func init() {
 	flag.IntVar(
 		&args.rate,
 		"rate",
-		100,
+		5,
 		"How many times (per second) should the endpoint be hit.",
 	)
 	flag.StringVar(

--- a/pkg/helpers/endpoints.go
+++ b/pkg/helpers/endpoints.go
@@ -4,4 +4,10 @@ const (
 	ClustersEndpoint = "/api/clusters_mgmt/v1/clusters"
 	VersionsEndpoint = "/api/clusters_mgmt/v1/versions"
 	FlavoursEndpoint = "/api/clusters_mgmt/v1/flavours"
+
+	// AMS
+	SelfAccessTokenEndpoint     = "/api/accounts_mgmt/v1/access_token"
+	ListSubscriptionsEndpoint   = "/api/accounts_mgmt/v1/subscriptions"
+	AccessReviewEndpoint        = "/api/authorizations/v1/access_review"
+	ClusterRegistrationEndpoint = "/api/accounts_mgmt/v1/cluster_registrations"
 )

--- a/pkg/tests/ams.go
+++ b/pkg/tests/ams.go
@@ -10,10 +10,19 @@ import (
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
-func TestSelfAccessToken(attacker *vegeta.Attacker, outputDirectory string, duration time.Duration, testID string) error {
+const (
+	defaultRate = 100
+)
+
+func TestSelfAccessToken(
+	attacker *vegeta.Attacker,
+	testID string,
+	metrics map[string]*vegeta.Metrics,
+	rate vegeta.Pacer,
+	outputDirectory string,
+	duration time.Duration) error {
 
 	testName := "self-access-token"
-	rate := vegeta.ConstantPacer{Freq: 1000, Per: time.Hour}
 	fileName := fmt.Sprintf("%s_%s", testID, testName)
 
 	target := vegeta.Target{
@@ -34,16 +43,22 @@ func TestSelfAccessToken(attacker *vegeta.Attacker, outputDirectory string, dura
 	fmt.Printf("Output File: %s/%s\n", outputDirectory, fileName)
 
 	for res := range attacker.Attack(targeter, rate, duration, testName) {
+		metrics[testName].Add(res)
 		result.Write(res, resultFile)
 	}
+	metrics[testName].Close()
 
 	return nil
 }
 
-func TestListSubscriptions(attacker *vegeta.Attacker, outputDirectory string, duration time.Duration, testID string) error {
+func TestListSubscriptions(attacker *vegeta.Attacker,
+	testID string,
+	metrics map[string]*vegeta.Metrics,
+	rate vegeta.Pacer,
+	outputDirectory string,
+	duration time.Duration) error {
 
 	testName := "list-subscriptions"
-	rate := vegeta.ConstantPacer{Freq: 2000, Per: time.Hour}
 	fileName := fmt.Sprintf("%s_%s", testID, testName)
 
 	target := vegeta.Target{
@@ -71,10 +86,14 @@ func TestListSubscriptions(attacker *vegeta.Attacker, outputDirectory string, du
 
 }
 
-func TestAccessReview(attacker *vegeta.Attacker, outputDirectory string, duration time.Duration, testID string) error {
+func TestAccessReview(attacker *vegeta.Attacker,
+	testID string,
+	metrics map[string]*vegeta.Metrics,
+	rate vegeta.Pacer,
+	outputDirectory string,
+	duration time.Duration) error {
 
 	testName := "access-review"
-	rate := vegeta.ConstantPacer{Freq: 100, Per: time.Second}
 	fileName := fmt.Sprintf("%s_%s", testID, testName)
 
 	target := vegeta.Target{
@@ -103,10 +122,14 @@ func TestAccessReview(attacker *vegeta.Attacker, outputDirectory string, duratio
 
 }
 
-func TestRegisterNewCluster(attacker *vegeta.Attacker, outputDirectory string, duration time.Duration, testID string) error {
+func TestRegisterNewCluster(attacker *vegeta.Attacker,
+	testID string,
+	metrics map[string]*vegeta.Metrics,
+	rate vegeta.Pacer,
+	outputDirectory string,
+	duration time.Duration) error {
 
 	testName := "new-cluster-registration"
-	rate := vegeta.ConstantPacer{Freq: 1000, Per: time.Hour}
 	fileName := fmt.Sprintf("%s_%s", testID, testName)
 
 	// TODO: Generate a UUID for each Request

--- a/pkg/tests/ams.go
+++ b/pkg/tests/ams.go
@@ -1,0 +1,136 @@
+package tests
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/nimrodshn/cs-load-test/pkg/helpers"
+	"github.com/nimrodshn/cs-load-test/pkg/result"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+)
+
+func TestSelfAccessToken(attacker *vegeta.Attacker, outputDirectory string, duration time.Duration, testID string) error {
+
+	testName := "self-access-token"
+	rate := vegeta.ConstantPacer{Freq: 1000, Per: time.Hour}
+	fileName := fmt.Sprintf("%s_%s", testID, testName)
+
+	target := vegeta.Target{
+		Method: http.MethodPost,
+		URL:    helpers.SelfAccessTokenEndpoint,
+	}
+
+	targeter := vegeta.NewStaticTargeter(target)
+	resultFile, err := createFile(fileName, outputDirectory)
+	defer resultFile.Close()
+	if err != nil {
+		return err
+	}
+
+	// Display some info about the test being ran to catch obvious issues
+	// and include context
+	fmt.Printf("Test: %s\n", testName)
+	fmt.Printf("Output File: %s/%s\n", outputDirectory, fileName)
+
+	for res := range attacker.Attack(targeter, rate, duration, testName) {
+		result.Write(res, resultFile)
+	}
+
+	return nil
+}
+
+func TestListSubscriptions(attacker *vegeta.Attacker, outputDirectory string, duration time.Duration, testID string) error {
+
+	testName := "list-subscriptions"
+	rate := vegeta.ConstantPacer{Freq: 2000, Per: time.Hour}
+	fileName := fmt.Sprintf("%s_%s", testID, testName)
+
+	target := vegeta.Target{
+		Method: http.MethodGet,
+		URL:    helpers.ListSubscriptionsEndpoint,
+	}
+
+	targeter := vegeta.NewStaticTargeter(target)
+	resultFile, err := createFile(fileName, outputDirectory)
+	defer resultFile.Close()
+	if err != nil {
+		return err
+	}
+
+	// Display some info about the test being ran to catch obvious issues
+	// and include context
+	fmt.Printf("Test: %s\n", testName)
+	fmt.Printf("Output File: %s/%s\n", outputDirectory, fileName)
+
+	for res := range attacker.Attack(targeter, rate, duration, testName) {
+		result.Write(res, resultFile)
+	}
+
+	return nil
+
+}
+
+func TestAccessReview(attacker *vegeta.Attacker, outputDirectory string, duration time.Duration, testID string) error {
+
+	testName := "access-review"
+	rate := vegeta.ConstantPacer{Freq: 100, Per: time.Second}
+	fileName := fmt.Sprintf("%s_%s", testID, testName)
+
+	target := vegeta.Target{
+		Method: http.MethodPost,
+		URL:    helpers.AccessReviewEndpoint,
+		Body:   []byte("{'account_username': 'rhn-support-tiwillia', 'action': 'get', 'resource_type': 'Subscription'}"),
+	}
+
+	targeter := vegeta.NewStaticTargeter(target)
+	resultFile, err := createFile(fileName, outputDirectory)
+	defer resultFile.Close()
+	if err != nil {
+		return err
+	}
+
+	// Display some info about the test being ran to catch obvious issues
+	// and include contextq
+	fmt.Printf("Test: %s\n", testName)
+	fmt.Printf("Output File: %s/%s\n", outputDirectory, fileName)
+
+	for res := range attacker.Attack(targeter, rate, duration, testName) {
+		result.Write(res, resultFile)
+	}
+
+	return nil
+
+}
+
+func TestRegisterNewCluster(attacker *vegeta.Attacker, outputDirectory string, duration time.Duration, testID string) error {
+
+	testName := "new-cluster-registration"
+	rate := vegeta.ConstantPacer{Freq: 1000, Per: time.Hour}
+	fileName := fmt.Sprintf("%s_%s", testID, testName)
+
+	target := vegeta.Target{
+		Method: http.MethodPost,
+		URL:    helpers.AccessReviewEndpoint,
+		Body:   []byte("{'account_username': 'rhn-support-tiwillia', 'action': 'get', 'resource_type': 'Subscription'}"),
+	}
+
+	targeter := vegeta.NewStaticTargeter(target)
+	resultFile, err := createFile(fileName, outputDirectory)
+	defer resultFile.Close()
+	if err != nil {
+		return err
+	}
+
+	// Display some info about the test being ran to catch obvious issues
+	// and include contextq
+	fmt.Printf("Test: %s\n", testName)
+	fmt.Printf("Output File: %s/%s\n", outputDirectory, fileName)
+
+	for res := range attacker.Attack(targeter, rate, duration, testName) {
+		result.Write(res, resultFile)
+	}
+
+	return nil
+
+}

--- a/pkg/tests/ams.go
+++ b/pkg/tests/ams.go
@@ -109,10 +109,12 @@ func TestRegisterNewCluster(attacker *vegeta.Attacker, outputDirectory string, d
 	rate := vegeta.ConstantPacer{Freq: 1000, Per: time.Hour}
 	fileName := fmt.Sprintf("%s_%s", testID, testName)
 
+	// TODO: Generate a UUID for each Request
+	// TODO: The authorization_token should be real. Not sure what to set it as, though.
 	target := vegeta.Target{
 		Method: http.MethodPost,
-		URL:    helpers.AccessReviewEndpoint,
-		Body:   []byte("{'account_username': 'rhn-support-tiwillia', 'action': 'get', 'resource_type': 'Subscription'}"),
+		URL:    helpers.ClusterRegistrationEndpoint,
+		Body:   []byte("{'authorization_token': 'specify-me', 'cluster_id': 'c98550e5-1c9f-47bb-b46f-b2b6e7befeb3'}"),
 	}
 
 	targeter := vegeta.NewStaticTargeter(target)

--- a/pkg/tests/ams.go
+++ b/pkg/tests/ams.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -25,6 +26,8 @@ func TestSelfAccessToken(
 	testName := "self-access-token"
 	fileName := fmt.Sprintf("%s_%s", testID, testName)
 
+	log.Printf("Executing Test: %s", testName)
+
 	target := vegeta.Target{
 		Method: http.MethodPost,
 		URL:    helpers.SelfAccessTokenEndpoint,
@@ -39,14 +42,16 @@ func TestSelfAccessToken(
 
 	// Display some info about the test being ran to catch obvious issues
 	// and include context
-	fmt.Printf("Test: %s\n", testName)
-	fmt.Printf("Output File: %s/%s\n", outputDirectory, fileName)
+	log.Printf("Test: %s\n", testName)
+	log.Printf("Output File: %s/%s\n", outputDirectory, fileName)
+
+	metrics[testName] = new(vegeta.Metrics)
+	defer metrics[testName].Close()
 
 	for res := range attacker.Attack(targeter, rate, duration, testName) {
 		metrics[testName].Add(res)
 		result.Write(res, resultFile)
 	}
-	metrics[testName].Close()
 
 	return nil
 }
@@ -60,6 +65,8 @@ func TestListSubscriptions(attacker *vegeta.Attacker,
 
 	testName := "list-subscriptions"
 	fileName := fmt.Sprintf("%s_%s", testID, testName)
+
+	log.Printf("Executing Test: %s", testName)
 
 	target := vegeta.Target{
 		Method: http.MethodGet,
@@ -78,12 +85,14 @@ func TestListSubscriptions(attacker *vegeta.Attacker,
 	fmt.Printf("Test: %s\n", testName)
 	fmt.Printf("Output File: %s/%s\n", outputDirectory, fileName)
 
+	metrics[testName] = new(vegeta.Metrics)
+	defer metrics[testName].Close()
+
 	for res := range attacker.Attack(targeter, rate, duration, testName) {
 		result.Write(res, resultFile)
 	}
 
 	return nil
-
 }
 
 func TestAccessReview(attacker *vegeta.Attacker,
@@ -96,10 +105,12 @@ func TestAccessReview(attacker *vegeta.Attacker,
 	testName := "access-review"
 	fileName := fmt.Sprintf("%s_%s", testID, testName)
 
+	log.Printf("Executing Test: %s", testName)
+
 	target := vegeta.Target{
 		Method: http.MethodPost,
 		URL:    helpers.AccessReviewEndpoint,
-		Body:   []byte("{'account_username': 'rhn-support-tiwillia', 'action': 'get', 'resource_type': 'Subscription'}"),
+		Body:   []byte("{\"account_username\": \"rhn-support-tiwillia\", \"action\": \"get\", \"resource_type\": \"Subscription\"}"),
 	}
 
 	targeter := vegeta.NewStaticTargeter(target)
@@ -113,6 +124,9 @@ func TestAccessReview(attacker *vegeta.Attacker,
 	// and include contextq
 	fmt.Printf("Test: %s\n", testName)
 	fmt.Printf("Output File: %s/%s\n", outputDirectory, fileName)
+
+	metrics[testName] = new(vegeta.Metrics)
+	defer metrics[testName].Close()
 
 	for res := range attacker.Attack(targeter, rate, duration, testName) {
 		result.Write(res, resultFile)
@@ -132,12 +146,14 @@ func TestRegisterNewCluster(attacker *vegeta.Attacker,
 	testName := "new-cluster-registration"
 	fileName := fmt.Sprintf("%s_%s", testID, testName)
 
+	log.Printf("Executing Test: %s", testName)
+
 	// TODO: Generate a UUID for each Request
 	// TODO: The authorization_token should be real. Not sure what to set it as, though.
 	target := vegeta.Target{
 		Method: http.MethodPost,
 		URL:    helpers.ClusterRegistrationEndpoint,
-		Body:   []byte("{'authorization_token': 'specify-me', 'cluster_id': 'c98550e5-1c9f-47bb-b46f-b2b6e7befeb3'}"),
+		Body:   []byte("{\"authorization_token\": \"specify-me\", \"cluster_id\": \"c98550e5-1c9f-47bb-b46f-b2b6e7befeb3\"}"),
 	}
 
 	targeter := vegeta.NewStaticTargeter(target)
@@ -151,6 +167,9 @@ func TestRegisterNewCluster(attacker *vegeta.Attacker,
 	// and include contextq
 	fmt.Printf("Test: %s\n", testName)
 	fmt.Printf("Output File: %s/%s\n", outputDirectory, fileName)
+
+	metrics[testName] = new(vegeta.Metrics)
+	defer metrics[testName].Close()
 
 	for res := range attacker.Attack(targeter, rate, duration, testName) {
 		result.Write(res, resultFile)

--- a/pkg/tests/clusters.go
+++ b/pkg/tests/clusters.go
@@ -21,6 +21,7 @@ const (
 )
 
 func TestListClusters(attacker *vegeta.Attacker,
+	testID string,
 	metrics map[string]*vegeta.Metrics,
 	rate vegeta.Pacer,
 	outputDirectory string,
@@ -49,6 +50,7 @@ func TestListClusters(attacker *vegeta.Attacker,
 }
 
 func TestCreateCluster(attacker *vegeta.Attacker,
+	testID string,
 	metrics map[string]*vegeta.Metrics,
 	rate vegeta.Pacer,
 	outputDirectory string,

--- a/pkg/tests/run.go
+++ b/pkg/tests/run.go
@@ -3,10 +3,12 @@ package tests
 import (
 	"time"
 
+	uuid "github.com/satori/go.uuid"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
 type testCase func(attacker *vegeta.Attacker,
+	testID string,
 	metrics map[string]*vegeta.Metrics,
 	rate vegeta.Pacer,
 	outputDirectory string,
@@ -19,10 +21,22 @@ func Run(
 	outputDirectory string,
 	duration time.Duration) error {
 
-	testCases := []testCase{TestCreateCluster, TestListClusters}
+	// testId is an identifier used to associate all tests in this test suite with each
+	// other
+	testID := uuid.NewV4().String()
+
+	testCases := []testCase{
+		TestCreateCluster,
+		TestListClusters,
+		TestSelfAccessToken,
+		TestListSubscriptions,
+		TestAccessReview,
+		TestRegisterNewCluster,
+	}
 
 	for _, testCase := range testCases {
 		err := testCase(attacker,
+			testID,
 			metrics,
 			rate,
 			outputDirectory,


### PR DESCRIPTION
This Pull Request adds some simple account/authorization related tests and reduces the default rate.

NOTE: The tests are still a work-in-progress but for the sake of synchronization, it may be useful to get them merged in. Specifically, the cluster registration endpoints will not work as expected in their current form as they need legitimate Pull Secrets and to keep track of the UUID for the "reauth" test.